### PR TITLE
Restore old scikit-learn version (because we use old Python)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pytest==8.1.1
 pytest-cov==5.0.0
 pytest-rerunfailures==14.0
 pytest-timeout==2.3.1
-scikit-learn==1.5.0
+scikit-learn==1.3.2
 scipy==1.10.1
 six==1.16.0
 strictyaml==1.7.3

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'plotly==5.20.0',
         'protobuf==3.20.3',  # BigARTM dependency
         'pytest==8.1.1',
-        'scikit-learn==1.5.0',
+        'scikit-learn==1.3.2',
         'scipy==1.10.1',
         'six==1.16.0',
         'strictyaml==1.7.3',


### PR DESCRIPTION
Reverts https://github.com/machine-intelligence-laboratory/TopicNet/pull/104.